### PR TITLE
Fix migrations issue

### DIFF
--- a/pages/api/v1/migrations/index.js
+++ b/pages/api/v1/migrations/index.js
@@ -1,4 +1,5 @@
 import { runner as migrationRunner } from "node-pg-migrate";
+import { resolve } from "node:path";
 import database from "infra/database";
 
 export default async function migrations(request, response) {
@@ -8,7 +9,7 @@ export default async function migrations(request, response) {
 
     const defaultMigrationOptions = {
       dbClient: dbClient,
-      dir: "infra/migrations",
+      dir: resolve("infra", "migrations"),
       direction: "up",
       dryRun: true,
       verbose: true,


### PR DESCRIPTION
use `resolve()` to correctly build the `infra/migrations` path on Vercel serverless environment