### PR TITLE
Cria e usa o método `orchestrator.createUser()`

### DIFF
--- a/models/user.js
+++ b/models/user.js
@@ -145,6 +145,12 @@ async function validateUniqueEmail(email) {
 }
 
 async function hashPasswordInObject(userInputValues) {
+  if (!userInputValues.password) {
+    throw new ValidationError({
+      message: "O campo 'senha' não pode estar vazio.",
+      action: "Digite uma senha para o usuário.",
+    });
+  }
   const hashedPassword = await password.hash(userInputValues.password);
   userInputValues.password = hashedPassword;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "@commitlint/cli": "19.8.1",
         "@commitlint/config-conventional": "19.8.1",
         "@eslint/js": "9.28.0",
+        "@faker-js/faker": "9.7.0",
         "commitizen": "4.3.1",
         "concurrently": "9.1.2",
         "cz-conventional-changelog": "3.3.0",
@@ -1195,6 +1196,23 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@faker-js/faker": {
+      "version": "9.7.0",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-9.7.0.tgz",
+      "integrity": "sha512-aozo5vqjCmDoXLNUJarFZx2IN/GgGaogY4TMJ6so/WLZOWpSV7fvj2dmrV6sEAnUm1O7aCrhTibjpzeDFgNqbg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fakerjs"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=9.0.0"
       }
     },
     "node_modules/@humanfs/core": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@commitlint/cli": "19.8.1",
     "@commitlint/config-conventional": "19.8.1",
     "@eslint/js": "9.28.0",
+    "@faker-js/faker": "9.7.0",
     "commitizen": "4.3.1",
     "concurrently": "9.1.2",
     "cz-conventional-changelog": "3.3.0",

--- a/tests/integration/api/v1/users/[username]/get.test.js
+++ b/tests/integration/api/v1/users/[username]/get.test.js
@@ -10,19 +10,11 @@ beforeAll(async () => {
 describe("GET /api/v1/users/[username]", () => {
   describe("Anonymous user", () => {
     test("With exact case match", async () => {
-      const response1 = await fetch("http://localhost:3000/api/v1/users", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          username: "MesmoCase",
-          email: "mesmo.case@gmail.com",
-          password: "senha123",
-        }),
+      await orchestrator.createUser({
+        username: "MesmoCase",
+        email: "mesmo.case@gmail.com",
+        password: "senha123",
       });
-
-      expect(response1.status).toBe(201);
 
       const response2 = await fetch(
         "http://localhost:3000/api/v1/users/MesmoCase",
@@ -46,19 +38,11 @@ describe("GET /api/v1/users/[username]", () => {
     });
 
     test("With case mismatch", async () => {
-      const response1 = await fetch("http://localhost:3000/api/v1/users", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          username: "CaseDiferente",
-          email: "case.diferente@gmail.com",
-          password: "senha123",
-        }),
+      await orchestrator.createUser({
+        username: "CaseDiferente",
+        email: "case.diferente@gmail.com",
+        password: "senha123",
       });
-
-      expect(response1.status).toBe(201);
 
       const response2 = await fetch(
         "http://localhost:3000/api/v1/users/casediferente",

--- a/tests/integration/api/v1/users/[username]/patch.test.js
+++ b/tests/integration/api/v1/users/[username]/patch.test.js
@@ -31,31 +31,13 @@ describe("PATCH /api/v1/users/[username]", () => {
     });
 
     test("With existing 'username'", async () => {
-      const user1Response = await fetch("http://localhost:3000/api/v1/users", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          username: "user1",
-          email: "user1@gmail.com",
-          password: "senha123",
-        }),
+      await orchestrator.createUser({
+        username: "user1",
       });
-      expect(user1Response.status).toBe(201);
 
-      const user2Response = await fetch("http://localhost:3000/api/v1/users", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          username: "user2",
-          email: "user2@gmail.com",
-          password: "senha123",
-        }),
+      await orchestrator.createUser({
+        username: "user2",
       });
-      expect(user2Response.status).toBe(201);
 
       const response = await fetch("http://localhost:3000/api/v1/users/user1", {
         method: "PATCH",
@@ -70,7 +52,7 @@ describe("PATCH /api/v1/users/[username]", () => {
       expect(response.status).toBe(400);
 
       const responseBody = await response.json();
-      expect(responseBody).toMatchObject({
+      expect({ ...responseBody }).toEqual({
         name: "ValidationError",
         message: "O nome de usuário informado já está sendo utilizado.",
         action: "Utilize outro nome de usuário para realizar esta operação.",
@@ -79,34 +61,11 @@ describe("PATCH /api/v1/users/[username]", () => {
     });
 
     test("With existing 'email'", async () => {
-      const email1Response = await fetch("http://localhost:3000/api/v1/users", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          username: "email1",
-          email: "email1@gmail.com",
-          password: "senha123",
-        }),
-      });
-      expect(email1Response.status).toBe(201);
-
-      const email2Response = await fetch("http://localhost:3000/api/v1/users", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          username: "email2",
-          email: "email2@gmail.com",
-          password: "senha123",
-        }),
-      });
-      expect(email2Response.status).toBe(201);
+      const existingEmail = await orchestrator.createUser();
+      await orchestrator.createUser({ email: "email2@gmail.com" });
 
       const response = await fetch(
-        "http://localhost:3000/api/v1/users/email1",
+        `http://localhost:3000/api/v1/users/${existingEmail.username}`,
         {
           method: "PATCH",
           headers: {
@@ -121,7 +80,7 @@ describe("PATCH /api/v1/users/[username]", () => {
       expect(response.status).toBe(400);
 
       const responseBody = await response.json();
-      expect(responseBody).toMatchObject({
+      expect({ ...responseBody }).toEqual({
         name: "ValidationError",
         message: "O email informado já está sendo utilizado.",
         action: "Utilize outro email para realizar esta operação.",
@@ -130,21 +89,10 @@ describe("PATCH /api/v1/users/[username]", () => {
     });
 
     test("With unique 'username'", async () => {
-      const user1Response = await fetch("http://localhost:3000/api/v1/users", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          username: "uniqueUser1",
-          email: "uniqueUser1@gmail.com",
-          password: "senha123",
-        }),
-      });
-      expect(user1Response.status).toBe(201);
+      const uniqueUsername = await orchestrator.createUser();
 
       const response = await fetch(
-        "http://localhost:3000/api/v1/users/uniqueUser1",
+        `http://localhost:3000/api/v1/users/${uniqueUsername.username}`,
         {
           method: "PATCH",
           headers: {
@@ -159,10 +107,10 @@ describe("PATCH /api/v1/users/[username]", () => {
       expect(response.status).toBe(200);
 
       const responseBody = await response.json();
-      expect(responseBody).toEqual({
+      expect({ ...responseBody }).toEqual({
         id: responseBody.id,
         username: "uniqueUser2",
-        email: "uniqueUser1@gmail.com",
+        email: uniqueUsername.email,
         password: responseBody.password,
         created_at: responseBody.created_at,
         updated_at: responseBody.updated_at,
@@ -175,21 +123,10 @@ describe("PATCH /api/v1/users/[username]", () => {
     });
 
     test("With unique 'email'", async () => {
-      const user1Response = await fetch("http://localhost:3000/api/v1/users", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          username: "uniqueEmail1",
-          email: "uniqueEmail1@gmail.com",
-          password: "senha123",
-        }),
-      });
-      expect(user1Response.status).toBe(201);
+      const uniqueEmail = await orchestrator.createUser();
 
       const response = await fetch(
-        "http://localhost:3000/api/v1/users/uniqueEmail1",
+        `http://localhost:3000/api/v1/users/${uniqueEmail.username}`,
         {
           method: "PATCH",
           headers: {
@@ -204,9 +141,9 @@ describe("PATCH /api/v1/users/[username]", () => {
       expect(response.status).toBe(200);
 
       const responseBody = await response.json();
-      expect(responseBody).toEqual({
+      expect({ ...responseBody }).toEqual({
         id: responseBody.id,
-        username: "uniqueEmail1",
+        username: uniqueEmail.username,
         email: "uniqueEmail2@gmail.com",
         password: responseBody.password,
         created_at: responseBody.created_at,
@@ -220,21 +157,10 @@ describe("PATCH /api/v1/users/[username]", () => {
     });
 
     test("With new 'password'", async () => {
-      const user1Response = await fetch("http://localhost:3000/api/v1/users", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          username: "newPassword1",
-          email: "newPassword1@gmail.com",
-          password: "newPassword1",
-        }),
-      });
-      expect(user1Response.status).toBe(201);
+      const newPassword = await orchestrator.createUser();
 
       const response = await fetch(
-        "http://localhost:3000/api/v1/users/newPassword1",
+        `http://localhost:3000/api/v1/users/${newPassword.username}`,
         {
           method: "PATCH",
           headers: {
@@ -249,10 +175,10 @@ describe("PATCH /api/v1/users/[username]", () => {
       expect(response.status).toBe(200);
 
       const responseBody = await response.json();
-      expect(responseBody).toEqual({
+      expect({ ...responseBody }).toEqual({
         id: responseBody.id,
-        username: "newPassword1",
-        email: "newPassword1@gmail.com",
+        username: newPassword.username,
+        email: newPassword.email,
         password: responseBody.password,
         created_at: responseBody.created_at,
         updated_at: responseBody.updated_at,
@@ -263,14 +189,14 @@ describe("PATCH /api/v1/users/[username]", () => {
       expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
       expect(responseBody.updated_at > responseBody.created_at).toBe(true);
 
-      const userInDatabase = await user.findOneByUsername("newPassword1");
+      const userInDatabase = await user.findOneByUsername(newPassword.username);
       const correctPasswordMatch = await password.compare(
         "newPassword2",
         userInDatabase.password,
       );
 
       const incorrectPasswordMatch = await password.compare(
-        "newPassword1",
+        "prototypePassword",
         userInDatabase.password,
       );
 

--- a/tests/integration/api/v1/users/post.test.js
+++ b/tests/integration/api/v1/users/post.test.js
@@ -26,7 +26,7 @@ describe("POST /api/v1/users", () => {
       expect(response.status).toBe(201);
 
       const responseBody = await response.json();
-      expect(responseBody).toEqual({
+      expect({ ...responseBody }).toEqual({
         id: responseBody.id,
         username: "rodrigoons",
         email: "rodrigoons@gmail.com",
@@ -83,7 +83,7 @@ describe("POST /api/v1/users", () => {
       expect(response2.status).toBe(400);
 
       const response2Body = await response2.json();
-      expect(response2Body).toMatchObject({
+      expect({ ...response2Body }).toEqual({
         name: "ValidationError",
         message: "O email informado já está sendo utilizado.",
         action: "Utilize outro email para realizar esta operação.",
@@ -120,7 +120,7 @@ describe("POST /api/v1/users", () => {
       expect(response3.status).toBe(400);
 
       const response3Body = await response3.json();
-      expect(response3Body).toMatchObject({
+      expect({ ...response3Body }).toEqual({
         name: "ValidationError",
         message: "O nome de usuário informado já está sendo utilizado.",
         action: "Utilize outro nome de usuário para realizar esta operação.",

--- a/tests/orchestrator.js
+++ b/tests/orchestrator.js
@@ -1,6 +1,8 @@
 import retry from "async-retry";
+import { faker } from "@faker-js/faker";
 import database from "infra/database";
 import migrator from "models/migrator.js";
+import user from "models/user.js";
 
 async function waitForAllServices() {
   await waitForWebServer();
@@ -32,8 +34,18 @@ async function runPendingMigrations() {
   await migrator.runPendingMigrations();
 }
 
+async function createUser(userObject = {}) {
+  return await user.create({
+    username:
+      userObject.username || faker.internet.username().replace(/[-_.]/g, ""),
+    email: userObject.email || faker.internet.email(),
+    password: userObject.password || "prototypePassword",
+  });
+}
+
 export default {
   waitForAllServices,
   clearDatabase,
   runPendingMigrations,
+  createUser,
 };


### PR DESCRIPTION
- Cria o método `createUser()`, simplificando e melhorando a legibilidade do código dos testes
- Corrige falha que permitia criação de usuário sem senha
- Ajusta código dos testes pra melhorar logs de erros do jest nas comparações diretas de objetos com `expect().toEqual()`